### PR TITLE
replace deprecated :frontend_prefix with :frontend_proxy_prefix

### DIFF
--- a/frontend/views/layout_head.html.erb
+++ b/frontend/views/layout_head.html.erb
@@ -7,7 +7,7 @@ end
 %>
 
 <% if AppConfig.has_key?(:user_defined_in_basic) %>
-    <%= javascript_include_tag "#{AppConfig[:frontend_prefix]}assets/user_defined_in_basic.js" %>
+    <%= javascript_include_tag "#{AppConfig[:frontend_proxy_prefix]}assets/user_defined_in_basic.js" %>
 
     <script>
      var fields = <%= ASUtils.to_json(map_user_defined_to_labels(AppConfig[:user_defined_in_basic].fetch(controller.controller_name, []))).html_safe %>;


### PR DESCRIPTION
AppConfig[:frontend_prefix] has been deprecated since ArchivesSpace release [v2.1.1](https://github.com/archivesspace/archivesspace/releases/tag/v2.1.1) (ArchivesSpace commit https://github.com/archivesspace/archivesspace/commit/0fc719d0710751feaf43da4e1898059b03208f0c). Using it in that release or later results in the following deprecation warning:
```
WARNING: The parameter 'frontend_prefix' is now deprecated.  Please use 'frontend_proxy_prefix' instead.
```