### PR TITLE
reformulated deprecated jQuery calls

### DIFF
--- a/frontend/assets/user_defined_in_basic.js
+++ b/frontend/assets/user_defined_in_basic.js
@@ -14,7 +14,7 @@ UserDefinedInBasic.prototype.init = function(fields, read_only_view, hide_user_d
     var user_defined_section = $('section.subrecord-form[data-object-name="user_defined"]');
     var remove_btn = user_defined_section.find('.subrecord-form-remove');
     if (remove_btn.length == 0) {
-        user_defined_section.find('.btn-default').filter(':visible').click();
+        user_defined_section.find('.btn-default').filter(':visible').trigger('click');
         window.scrollTo(0,0);
     }
 

--- a/frontend/views/layout_head.html.erb
+++ b/frontend/views/layout_head.html.erb
@@ -26,12 +26,14 @@ end
      }
 
      // For Resource record updates
-     $(document).bind("loadedrecordform.aspace", init);
+     $(document).on("loadedrecordform.aspace", init);
 
      // For everything else
      // had to bind this call to window load because a bare call to init()
      // was causing Firefox to jump the gun ... javascript, sheesh
-     $(window).load(init);
+     $(window).on('load', function(){
+       init
+    })
 
     </script>
 


### PR DESCRIPTION
When experimenting with ArchivesSpace-v4.0.0-RC1, the `user_defined_in_basic` plugin triggered an infinite reload for pages where it was active. The small modifications in this commit seem to fix them: they provide modern equivalents for deprecated jQuery functions.